### PR TITLE
Diff Session Management

### DIFF
--- a/web/components/project/hooks/useCodeDiffer.ts
+++ b/web/components/project/hooks/useCodeDiffer.ts
@@ -140,13 +140,17 @@ export function useCodeDiffer({
     }
   }, [editorRef])
 
-  return {
-    handleApplyCode,
-    hasActiveWidgets: () =>
-      widgetManagerRef.current?.hasActiveWidgets() ?? false,
-    forceClearAllDecorations: () =>
-      widgetManagerRef.current?.forceClearAllDecorations(),
-    getUnresolvedSnapshot: (fileId: string) => {
+  // Memoize functions to prevent unnecessary re-renders
+  const hasActiveWidgets = useCallback(() => {
+    return widgetManagerRef.current?.hasActiveWidgets() ?? false
+  }, [])
+
+  const forceClearAllDecorations = useCallback(() => {
+    widgetManagerRef.current?.forceClearAllDecorations()
+  }, [])
+
+  const getUnresolvedSnapshot = useCallback(
+    (fileId: string) => {
       if (!editorRef) return null
       const model = editorRef.getModel()
       if (!model) return null
@@ -196,7 +200,11 @@ export function useCodeDiffer({
         unresolvedBlocks: unresolved,
       }
     },
-    restoreFromSnapshot: (session: DiffSession) => {
+    [editorRef]
+  )
+
+  const restoreFromSnapshot = useCallback(
+    (session: DiffSession) => {
       if (!editorRef) return
       const model = editorRef.getModel()
       if (!model) return
@@ -260,10 +268,21 @@ export function useCodeDiffer({
       )
       widgetManagerRef.current.buildAllWidgetsFromDecorations()
     },
-    clearVisuals: () => {
-      // Suppress session clearing when we intentionally clear visuals on tab switch
-      suppressZeroNotifyRef.current = true
-      widgetManagerRef.current?.forceClearAllDecorations()
-    },
+    [editorRef]
+  )
+
+  const clearVisuals = useCallback(() => {
+    // Suppress session clearing when we intentionally clear visuals on tab switch
+    suppressZeroNotifyRef.current = true
+    widgetManagerRef.current?.forceClearAllDecorations()
+  }, [])
+
+  return {
+    handleApplyCode,
+    hasActiveWidgets,
+    forceClearAllDecorations,
+    getUnresolvedSnapshot,
+    restoreFromSnapshot,
+    clearVisuals,
   }
 }

--- a/web/components/project/hooks/useDiffSessionManager.ts
+++ b/web/components/project/hooks/useDiffSessionManager.ts
@@ -1,0 +1,90 @@
+import { TTab } from "@/lib/types"
+import { useAppStore } from "@/store/context"
+import { useCallback, useEffect, useRef } from "react"
+
+/**
+ * Custom hook that manages diff sessions when switching between files
+ * This ensures diff sessions are saved/restored regardless of how files are opened
+ */
+export function useDiffSessionManager(
+  hasActiveWidgets: () => boolean,
+  getUnresolvedSnapshot: (fileId: string) => any,
+  restoreFromSnapshot: (session: any) => void,
+  clearVisuals: () => void,
+  forceClearAllDecorations: () => void
+) {
+  const activeTab = useAppStore((s) => s.activeTab)
+  const setActiveTab = useAppStore((s) => s.setActiveTab)
+  const saveDiffSession = useAppStore((s) => s.saveDiffSession)
+  const getDiffSession = useAppStore((s) => s.getDiffSession)
+  const clearDiffSession = useAppStore((s) => s.clearDiffSession)
+
+  const previousActiveTabRef = useRef<string | undefined>(activeTab?.id)
+
+  // Sync the ref with the current activeTab from store
+  useEffect(() => {
+    if (activeTab?.id && activeTab.id !== previousActiveTabRef.current) {
+      previousActiveTabRef.current = activeTab.id
+    }
+  }, [activeTab?.id])
+
+  /**
+   * Enhanced setActiveTab that handles diff sessions
+   */
+  const handleSetActiveTab = useCallback(
+    (tab: TTab) => {
+      // Save diff session for previous file if it has unresolved widgets
+      if (
+        previousActiveTabRef.current &&
+        previousActiveTabRef.current !== tab.id
+      ) {
+        if (hasActiveWidgets()) {
+          try {
+            const session = getUnresolvedSnapshot(previousActiveTabRef.current)
+            if (session) {
+              saveDiffSession(previousActiveTabRef.current, session)
+            }
+          } catch (error) {
+            console.warn("Failed to snapshot unresolved diffs:", error)
+          }
+        }
+
+        // Clear widgets from previous file
+        try {
+          clearVisuals()
+        } catch (error) {
+          forceClearAllDecorations()
+        }
+      }
+
+      // Update the active tab
+      setActiveTab(tab)
+      previousActiveTabRef.current = tab.id
+
+      // Restore diff session for new file if it exists
+      setTimeout(() => {
+        const session = getDiffSession(tab.id)
+        if (session && session.unresolvedBlocks.length > 0) {
+          try {
+            restoreFromSnapshot(session)
+          } catch (error) {
+            console.warn("Failed to restore diff session:", error)
+          }
+        }
+      }, 50) // Small delay to ensure editor is ready
+    },
+    [
+      hasActiveWidgets,
+      getUnresolvedSnapshot,
+      saveDiffSession,
+      clearVisuals,
+      forceClearAllDecorations,
+      getDiffSession,
+      restoreFromSnapshot,
+    ]
+  )
+
+  return {
+    handleSetActiveTab,
+  }
+}

--- a/web/components/project/sidebar/file.tsx
+++ b/web/components/project/sidebar/file.tsx
@@ -17,17 +17,27 @@ import { useAppStore } from "@/store/context"
 import { useDraggable } from "@dnd-kit/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useParams } from "next/navigation"
+import { useDiffSessionManager } from "../hooks/useDiffSessionManager"
 import { useFileContent, useFileTree } from "../hooks/useFile"
 
 const HOVER_PREFETCH_DELAY = 100
 const SidebarFile = memo((props: TFile) => {
   const { id: projectId } = useParams<{ id: string }>()
-  const setActiveTab = useAppStore((s) => s.setActiveTab)
   const queryClient = useQueryClient()
   const { deleteFile, renameFile, isDeletingFile } = useFileTree()
   const { prefetchFileContent } = useFileContent({
     id: props.id,
   })
+
+  // Get the diff functions from the project layout context
+  const diffFunctions = useAppStore((s) => s.diffFunctions)
+  const { handleSetActiveTab } = useDiffSessionManager(
+    diffFunctions?.hasActiveWidgets || (() => false),
+    diffFunctions?.getUnresolvedSnapshot || (() => null),
+    diffFunctions?.restoreFromSnapshot || (() => {}),
+    diffFunctions?.clearVisuals || (() => {}),
+    diffFunctions?.forceClearAllDecorations || (() => {})
+  )
   const { ref, isDragging } = useDraggable({
     id: props.id,
     type: props.type,
@@ -48,7 +58,7 @@ const SidebarFile = memo((props: TFile) => {
         fileId: props.id,
       })
     )
-    setActiveTab(newTab)
+    handleSetActiveTab(newTab)
   }
   const handleMouseEnter = () => {
     if (!editing && !isDeletingFile) {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -145,6 +145,16 @@ export interface DiffResult {
   granularBlocks: DiffBlock[]
 }
 
+// Persisted unresolved diff session for a file
+export interface DiffSession {
+  fileId: string
+  originalCode: string
+  mergedCode: string
+  combinedText: string
+  eol: "LF" | "CRLF"
+  unresolvedBlocks: { type: "added" | "removed"; start: number; end: number }[]
+}
+
 // Widget creation options
 
 export interface WidgetOptions {

--- a/web/store/slices/editor.ts
+++ b/web/store/slices/editor.ts
@@ -1,4 +1,4 @@
-import { TTab } from "@/lib/types"
+import { DiffSession, TTab } from "@/lib/types"
 import { StateCreator } from ".."
 
 interface EditorSlice {
@@ -9,6 +9,15 @@ interface EditorSlice {
   unsavedAlert: boolean
   toBeRemovedTab?: TTab
   drafts: Record<string, string>
+  diffSessions: Record<string, DiffSession>
+  editorRef: any
+  diffFunctions: {
+    hasActiveWidgets: () => boolean
+    getUnresolvedSnapshot: (fileId: string) => any
+    restoreFromSnapshot: (session: any) => void
+    clearVisuals: () => void
+    forceClearAllDecorations: () => void
+  } | null
 
   // Actions
   setTabs: (tabs: TTab[] | ((previousTabs: TTab[]) => TTab[])) => void
@@ -20,6 +29,17 @@ interface EditorSlice {
   setDraft: (fileId: string, content: string) => void
   clearDraft: (fileId: string) => void
   getDraft: (fileId: string) => string | undefined
+  saveDiffSession: (fileId: string, session: DiffSession) => void
+  getDiffSession: (fileId: string) => DiffSession | undefined
+  clearDiffSession: (fileId: string) => void
+  setEditorRef: (ref: any) => void
+  setDiffFunctions: (functions: {
+    hasActiveWidgets: () => boolean
+    getUnresolvedSnapshot: (fileId: string) => any
+    restoreFromSnapshot: (session: any) => void
+    clearVisuals: () => void
+    forceClearAllDecorations: () => void
+  }) => void
 }
 
 const createEditorSlice: StateCreator<EditorSlice> = (set, get) => ({
@@ -28,6 +48,9 @@ const createEditorSlice: StateCreator<EditorSlice> = (set, get) => ({
   activeTabContent: "",
   unsavedAlert: false,
   drafts: {},
+  diffSessions: {},
+  editorRef: null,
+  diffFunctions: null,
   // #endregion
 
   //   #region Actions
@@ -41,9 +64,10 @@ const createEditorSlice: StateCreator<EditorSlice> = (set, get) => ({
   },
   setActiveTab: (tabOrUpdater) => {
     set((state) => {
-      const newActiveTab = typeof tabOrUpdater === "function"
-        ? tabOrUpdater(state.activeTab)
-        : tabOrUpdater
+      const newActiveTab =
+        typeof tabOrUpdater === "function"
+          ? tabOrUpdater(state.activeTab)
+          : tabOrUpdater
 
       if (!newActiveTab) {
         return { activeTab: newActiveTab }
@@ -129,6 +153,21 @@ const createEditorSlice: StateCreator<EditorSlice> = (set, get) => ({
     }),
 
   getDraft: (fileId) => get().drafts[fileId],
+
+  saveDiffSession: (fileId, session) =>
+    set((state) => ({
+      diffSessions: { ...state.diffSessions, [fileId]: session },
+    })),
+  getDiffSession: (fileId) => get().diffSessions[fileId],
+  clearDiffSession: (fileId) =>
+    set((state) => {
+      const { [fileId]: _, ...rest } = state.diffSessions
+      return { diffSessions: rest }
+    }),
+
+  setEditorRef: (ref) => set({ editorRef: ref }),
+
+  setDiffFunctions: (functions) => set({ diffFunctions: functions }),
 
   //   #endregion
 })


### PR DESCRIPTION
# PR: Persist and Restore Unresolved Diffs Across File Navigation
#117 

## 🎯 Overview

This PR implements persistent diff session management that allows users to maintain unresolved diffs (red/green lines with accept/reject buttons) when switching between files, closing tabs, or reopening files. The diff view is restored exactly where the user left off, showing remaining unresolved changes.

## 🚀 Features

### ✨ Core Functionality

- **Persistent Diff Sessions**: Unresolved diffs are automatically saved when switching files or closing tabs
- **Seamless Restoration**: Diff view is restored exactly as left when returning to files
- **Cross-Navigation Support**: Works with tab switching, sidebar file opening, and file closing/reopening
- **Visual State Preservation**: Maintains decorations, widgets, and button states

### 🔧 Technical Improvements

- **Centralized Session Management**: New `useDiffSessionManager` hook for consistent behavior
- **Widget Lifecycle Management**: Enhanced `WidgetManager` with proper cleanup and restoration
- **State Serialization**: Complete diff state capture including decorations and unresolved blocks

## 📁 Files Changed

### New Files

- `web/components/project/hooks/useDiffSessionManager.ts` - Centralized diff session management

### Modified Files

- `web/store/slices/editor.ts` - Added diff session state management
- `web/components/project/hooks/useCodeDiffer.ts` - Enhanced with session persistence
- `web/components/project/hooks/lib/widget-manager.ts` - Improved widget lifecycle
- `web/components/project/project-layout.tsx` - Integrated session management
- `web/components/project/sidebar/file.tsx` - Updated to use session manager

## 🔄 User Experience Flow

### Before

1. Apply diff from AI chat → Creates unresolved diffs ✅
2. Switch to another file → **Diff view lost** ❌
3. Return to original file → **No diff restoration** ❌
4. Close and reopen file → **Diff view gone** ❌

### After

1. Apply diff from AI chat → Creates unresolved diffs ✅
2. Switch to another file → **Diff session saved** ✅
3. Return to original file → **Diff view restored** ✅
4. Close and reopen file → **Diff view restored** ✅

### Sidebar Navigation

- Apply diff to current file
- Open another file from sidebar
- Return to original file → Diff view restored

