### PR TITLE
fix: replaced floating buttons with top toolbar

### DIFF
--- a/web/components/ui/code-block-actions.tsx
+++ b/web/components/ui/code-block-actions.tsx
@@ -17,6 +17,7 @@ export interface CodeBlockActionsProps {
   className?: string
   isForCurrentFile?: boolean
   intendedFile?: string | null
+  placement?: "floating" | "toolbar"
 }
 
 export function CodeBlockActions({
@@ -28,6 +29,8 @@ export function CodeBlockActions({
   isForCurrentFile,
   intendedFile,
 }: CodeBlockActionsProps) {
+  const placement =
+    (arguments[0] as CodeBlockActionsProps).placement ?? "floating"
   const [isApplied, setIsApplied] = useState(false)
   const [isRejected, setIsRejected] = useState(false)
   const activeTab = useAppStore((s) => s.activeTab)
@@ -115,12 +118,15 @@ export function CodeBlockActions({
     rejectHandler?.()
   }
 
-  // Position controls beside the copy button (top-right), mirroring its behavior
-  const positioned = cn(
-    "absolute top-2 right-10 shrink-0 flex items-center gap-1",
-    "opacity-0 group-hover:opacity-100 transition-all",
-    className
-  )
+  // Position controls
+  const positioned =
+    placement === "floating"
+      ? cn(
+          "absolute top-2 right-10 shrink-0 flex items-center gap-1",
+          "opacity-0 group-hover:opacity-100 transition-all",
+          className
+        )
+      : cn("flex items-center gap-1", className)
 
   if (isApplied) {
     return (

--- a/web/components/ui/code-block.tsx
+++ b/web/components/ui/code-block.tsx
@@ -16,6 +16,8 @@ import { type BundledLanguage, codeToHtml } from "shiki"
 type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
   code: string
   language: BundledLanguage
+  filename?: string
+  showToolbar?: boolean
 }
 
 type CodeBlockContextType = {
@@ -39,6 +41,8 @@ export async function highlightCode(code: string, language: BundledLanguage) {
 const CodeBlock = ({
   code,
   language,
+  filename,
+  showToolbar = false,
   className,
   children,
   ...props
@@ -61,17 +65,26 @@ const CodeBlock = ({
 
   return (
     <CodeBlockContext.Provider value={{ code }}>
-      <div className="group relative">
+      <div className="group relative my-4 rounded-lg border overflow-hidden">
+        {showToolbar && (
+          <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/40">
+            <div className="text-xs font-medium truncate max-w-[60%]">
+              {filename ?? "code"}
+            </div>
+            <div className="flex items-center gap-1">{children}</div>
+          </div>
+        )}
         <div
           className={cn(
-            "overflow-x-auto my-4 h-auto rounded-lg border [&>pre]:p-4 [&>pre]:overflow-x-auto [&>pre]:min-w-0",
+            "overflow-x-auto h-auto [&>pre]:p-4 [&>pre]:overflow-x-auto [&>pre]:min-w-0",
+            !showToolbar && "rounded-lg border",
             className
           )}
           // biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
           dangerouslySetInnerHTML={{ __html: html }}
           {...props}
         />
-        {children}
+        {!showToolbar && children}
       </div>
     </CodeBlockContext.Provider>
   )
@@ -112,8 +125,7 @@ const CodeBlockCopyButton = ({
   return (
     <button
       className={cn(
-        "absolute top-2 right-2 shrink-0 rounded-md size-7 flex items-center justify-center opacity-0 transition-all",
-        "hover:bg-secondary group-hover:opacity-100 active:scale-95",
+        "rounded-md size-7 flex items-center justify-center transition-all hover:bg-secondary active:scale-95",
         className
       )}
       onClick={copyToClipboard}

--- a/web/components/ui/markdown.tsx
+++ b/web/components/ui/markdown.tsx
@@ -68,19 +68,27 @@ export const Markdown = memo(
               code = children
             }
 
+            // Determine a filename for the toolbar from the intended file path
+            const filename = firstIntendedFile
+              ? firstIntendedFile.split("/").pop() || firstIntendedFile
+              : undefined
+
             return (
               <CodeBlock
                 className={cn(className)}
                 code={code}
                 language={language}
+                filename={filename}
+                showToolbar
               >
-                <CodeBlockCopyButton />
-                {/* Pass the precomputed intended file directly */}
+                {/* Toolbar actions (Apply, Reject, Copy) */}
                 <CodeBlockActions
                   code={code}
                   language={language}
                   intendedFile={firstIntendedFile}
+                  placement="toolbar"
                 />
+                <CodeBlockCopyButton className="size-7" />
               </CodeBlock>
             )
           },


### PR DESCRIPTION
Replaced floating buttons with Toolbar in code blocks.

<img width="382" height="238" alt="image" src="https://github.com/user-attachments/assets/f4f9ab18-676f-4eff-84df-c35b11b25bc8" />
