### PR TITLE
Fix space at right of code block

### DIFF
--- a/web/components/project/chat/components/message.tsx
+++ b/web/components/project/chat/components/message.tsx
@@ -152,7 +152,7 @@ const MessageContent = ({
   return (
     <div
       className={cn(
-        "flex flex-col gap-0.5 max-w-[90%] sm:max-w-[85%] group pb-1",
+        "flex flex-col gap-0.5 max-w-full sm:max-w-full group pb-1",
         role === "assistant" ? "items-start" : "items-end"
       )}
     >


### PR DESCRIPTION
Increase maxwidth of AI generated messafe  to 100% to make sure no space on right side.

<img width="574" height="856" alt="image" src="https://github.com/user-attachments/assets/17223d71-5aed-447b-84b9-26c025a6dc5a" />
